### PR TITLE
Add Orionjs Packages to the Example blog Readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,14 @@ This example covers the following points:
 - Allow users registration
 - Orion Permissions
 - Orion pages package
+
+## Orion Packages
+
+Below is a list of `Orion Packages` used to build this blog example.
+
+- [orionjs:bootstrap](https://github.com/orionjs/bootstrap/)
+- [orionjs:file-attribute](https://github.com/orionjs/file-attribute)
+- [orionjs:froala-editor](https://github.com/orionjs/froala-editor)
+- [orionjs:filesystem](https://github.com/orionjs/filesystem)
+- [orionjs:s3](https://github.com/orionjs/s3)
+- [orionjs:pages](https://github.com/orionjs/pages)


### PR DESCRIPTION
This is an issue in the orion core repository. I am updating the readme to list the packages and links to the packages that are currently being used in the Orion example blog repository.