### PR TITLE
update packages to work with chrome fix

### DIFF
--- a/standard/.meteor/packages
+++ b/standard/.meteor/packages
@@ -29,4 +29,5 @@ orionjs:pages
 orionjs:image-attribute
 nicolaslopezj:orion-ga
 timfam:meetup
+iron:middleware-stack@1.1.0
 

--- a/standard/.meteor/versions
+++ b/standard/.meteor/versions
@@ -28,13 +28,13 @@ htmljs@1.0.4
 http@1.1.0
 id-map@1.0.3
 iron:controller@1.0.8
-iron:core@1.0.8
+iron:core@1.0.11
 iron:dynamic-template@1.0.8
 iron:layout@1.0.8
 iron:location@1.0.9
-iron:middleware-stack@1.0.9
+iron:middleware-stack@1.1.0
 iron:router@1.0.9
-iron:url@1.0.9
+iron:url@1.0.11
 jeremy:selectize@0.12.1_3
 jquery@1.11.3_2
 json@1.0.3


### PR DESCRIPTION
address this issue so the 'standard' example works properly via https://forums.meteor.com/t/meteor-orionjs-extend-user-profile-and-add-an-profile-picture/12905
